### PR TITLE
fix: only run pre-commit on branches that are not main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         run: poetry run tox
 
       - name: Lint
+        if: github.ref != 'refs/heads/main'
         run: |
           source $(poetry env info --path)/bin/activate
           pre-commit install --install-hooks


### PR DESCRIPTION
### Issue / Motivation

fix: only run pre-commit on branches that are not main

### Changes

This PR implements the following changes:

1. fix: only run pre-commit on branches that are not main
