### PR TITLE
fix: replace shell with env activate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,18 @@ help: ## show this help
 	@fgrep -h " ## " $(MAKEFILE_LIST) | fgrep -v fgrep | sed -Ee 's/([a-z.]*):[^#]*##(.*)/\1##\2/' | column -t -s "##"
 	@echo
 
-env: ## Create a virtual environment
+environment: ## Create a virtual environment
 	poetry install --sync
-	poetry shell
+	poetry env activate
 
-lint: env ## Lint and format the code
+lint: environment ## Lint and format the code
 	black .
 	ruff check .
 	mypy --ignore-missing-imports -p src
 	codespell .
 	refurb .
 
-test: env ## Run the unit tests and linters
+test: environment ## Run the unit tests and linters
 	pytest -vv --cov=src --cov-report=term-missing --cov-fail-under=50 tests
 
 install: ## Install dependencies
@@ -29,5 +29,5 @@ install: ## Install dependencies
 tox: install ## Run linting/testing in parallel for multiple Python versions
 	@poetry run tox -p
 
-shell: .env install ## Start the poetry shell
-	@poetry shell
+shell: environment install ## Start the poetry shell
+	@poetry env activate


### PR DESCRIPTION
### Issue / Motivation

replace `shell` with `env activate`. not a direct 1:1 replacemebnt but avoids needing to install the shell plugin.
