### PR TITLE
fix: migrate to avoid pre-commit deprecations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@
 #
 
 default_stages:
-  - commit
+  - pre-commit
 
 default_install_hook_types:
   - pre-commit
@@ -116,7 +116,7 @@ repos:
           - commit-msg
       - id: commitizen-branch
         stages:
-          - push
+          - pre-push
         args:
           - --rev-range
           - HEAD^!


### PR DESCRIPTION
### Issue / Motivation

Fixes:

> Warning:  hook id `commitizen-branch` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
